### PR TITLE
We have to escape the incoming windows filename with single slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ module.exports = function (file, opts) {
     data += buf
     next()
   }, function (next) {
+    var f = file.replace(/\\/gi, '\\\\')
     this.push(data)
-    this.push(' \nmodule.exports.__filename__ = "' + (opts.stripCwd ? path.relative(process.cwd(), file) : file) + '"\n ')
+    this.push(' \nmodule.exports.__filename__ = "' + (opts.stripCwd ? path.relative(process.cwd(), f) : f) + '"\n ')
     this.push(null)
     next()
   })

--- a/test.js
+++ b/test.js
@@ -55,3 +55,15 @@ test('strips cwd from filename export', function (t) {
         t.end()
       })
 })
+
+test('escapes quotes on windows', function (t) {
+  var data = ''
+  rs().pipe(transform('scripts\\foo.js', {}))
+      .on('data', function (d) {
+        data += d
+      })
+      .on('end', function () {
+        t.equal(data, 'module.exports = function () {} \nmodule.exports.__filename__ = "scripts\\\\foo.js"\n ', '__filename__ exported')
+        t.end()
+      })
+})


### PR DESCRIPTION
because the output goes into JS and breaks with a single slash . e.g.
"\upload-form.js" will use the \u escape char.
