### PR TITLE
prevent runtime error when module.exports doesn't exists (like with

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function (file, opts) {
     // Replace windows back slashes with forward slashes because browserify transform seem to choke with escaping correctly
     var f = (opts.stripCwd ? path.relative(process.cwd(), file) : file).replace(/\\/gi, '/')
     this.push(data)
-    this.push(' \nmodule.exports.__filename__ = "' + f + '"\n ')
+    this.push(' \nif (module && module.exports) { module.exports.__filename__ = "' + f + '" }\n ')
     this.push(null)
     next()
   })

--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ test('appends full path as __filename__ on module.exports', function (t) {
         data += d
       })
       .on('end', function () {
-        t.equal(data, 'module.exports = function () {} \nmodule.exports.__filename__ = "' + filename + '"\n ', '__filename__ exported')
+        t.equal(data, 'module.exports = function () {} \nif (module && module.exports) { module.exports.__filename__ = "' + filename + '" }\n ', '__filename__ exported')
         t.end()
       })
 })
@@ -51,7 +51,7 @@ test('strips cwd from filename export', function (t) {
         data += d
       })
       .on('end', function () {
-        t.equal(data, 'module.exports = function () {} \nmodule.exports.__filename__ = "' + out + '"\n ', '__filename__ exported')
+        t.equal(data, 'module.exports = function () {} \nif (module && module.exports) { module.exports.__filename__ = "' + out + '" }\n ', '__filename__ exported')
         t.end()
       })
 })
@@ -63,7 +63,7 @@ test('escapes quotes on windows', function (t) {
         data += d
       })
       .on('end', function () {
-        t.equal(data, 'module.exports = function () {} \nmodule.exports.__filename__ = "scripts/foo.js"\n ', '__filename__ exported')
+        t.equal(data, 'module.exports = function () {} \nif (module && module.exports) { module.exports.__filename__ = "scripts/foo.js" }\n ', '__filename__ exported')
         t.end()
       })
 })


### PR DESCRIPTION
browserify-shim modules)

see https://github.com/SpiderStrategies/Scoreboard/issues/9646